### PR TITLE
Update package.json to include a "watch" script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "watch": "watch 'npm run build' ./src"
   },
   "dependencies": {
     "@tailwindcss/aspect-ratio": "^0.4.2",


### PR DESCRIPTION
This patch simply adds a "watch" script into the frontend/package.json. This allows for easier testing as you can just run 'npm run watch' and once you make and save changes, everything will be rebuilt for you.